### PR TITLE
Connect Deck Detail Page with Backend deck/summary

### DIFF
--- a/client/components/DeckContainer/DeckContainer.jsx
+++ b/client/components/DeckContainer/DeckContainer.jsx
@@ -28,13 +28,13 @@ const DeckContainer = () => {
 
     const body = JSON.stringify({ deckName: newDeck, cards: [] });
 
-    const response = await fetch("http://localhost:3000", {
+    const response = await fetch("http://localhost:3000/deck", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body,
     });
 
-    if (response.status === 200) {
+    if (response.status === 201) {
       await getDecks();
       setNewDeck("");
     }

--- a/client/redux/currentDeckSlice.js
+++ b/client/redux/currentDeckSlice.js
@@ -23,7 +23,7 @@ export const currentDeckSlice = createSlice({
       );
     },
     getProgress: (state, action) => {
-      state.deckprogress = action.payload;
+      state.deckprogress = [action.payload];
     },
   },
 });
@@ -31,4 +31,4 @@ export const currentDeckSlice = createSlice({
 export const { selectDeck, loadCards, addCard, deleteCard, getProgress } =
   currentDeckSlice.actions;
 
-export default currentDeckSlice.reducers;
+export default currentDeckSlice.reducer;

--- a/client/styles.css
+++ b/client/styles.css
@@ -446,9 +446,22 @@ a {
   transform: translateY(-25px);
 }
 
+.deck-summary h1 {
+  font-family: "Verdana", sans-serif;
+  color: #007bff;
+  font-size: 2.5rem;
+}
+
 .deck-stats p {
-  font-size: 1.5rem;
+  font-family: "Arial", sans-serif;
+  line-height: 1.6;
+  font-size: 1.6rem;
+  margin-bottom: 10px;
   color: #333;
+}
+
+.deck-stats span {
+  color: #ff9843;
 }
 
 .deck-detail-button {

--- a/client/utils/requests.js
+++ b/client/utils/requests.js
@@ -11,13 +11,22 @@ export const getDecks = async () => {
   }
 };
 
-export const getDeckProgress = async (deckId) => {
-  // TODO: Update the address
-  // const response = await fetch("http://localhost:3000");
-  // if (response.status === 200) {
-  //   const body = await response.json();
-  //   store.dispatch(getProgress(body));
-  // }
+export const getDeckProgress = (deckId) => {
+  return async (dispatch) => {
+    try {
+      const body = JSON.stringify({ deckId: deckId });
+
+      const response = await fetch(`http://localhost:3000/deck/summary`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body,
+      });
+      const content = await response.json();
+      store.dispatch(getProgress(content));
+    } catch (error) {
+      console.error("Error fetching watch list:", error);
+    }
+  };
 };
 
 export const updateCardStatus = (updateInfo) => {


### PR DESCRIPTION
This PR contains changes that:
- Connects frontend data with backend route `/deck/summary` 
- Data in DeckDetail page will be retrieved from backend
- Able to handle empty deck situation
- Bug fix in the reducer output

<img width="1676" alt="image" src="https://github.com/Codesmith-Heat-Seeking-Devil-Chicken/Flashcard-App/assets/35018861/22d1931c-4bbb-402e-b6d4-bbb433eba113">
<img width="1569" alt="image" src="https://github.com/Codesmith-Heat-Seeking-Devil-Chicken/Flashcard-App/assets/35018861/2d19eaf9-c278-483b-9c10-b67b7a023580">


